### PR TITLE
Update faas-node to version 0.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM playfulcorgi/faas-node
+FROM playfulcorgi/faas-node:0.12.0
 COPY . ./
 RUN yarn install
 ENV HANDLER_FILE_SUBPATH="dist/index.js"

--- a/package.json
+++ b/package.json
@@ -7,10 +7,9 @@
   "scripts": {
     "build": "node-transpile build",
     "watch": "node-transpile watch",
-
     "docker-build": "docker build -t cherrypicked .",
-    "docker-run-development": "docker run -ti -v \"$(pwd)\":/app --name cherrypicked --rm -p 8835:80 cherrypicked",
-    "docker-run-production": "docker run -ti --name cherrypicked --rm -p 8835:80 --env-file .env cherrypicked"
+    "docker-run-development": "docker run -ti -v \"$(pwd)\":/app --name cherrypicked --rm -p 8835:8888 --env-file .env cherrypicked",
+    "docker-run-production": "docker run -ti --name cherrypicked --rm -p 8835:8888 --env-file .env cherrypicked"
   },
   "author": "playfulcorgi",
   "license": "ISC",
@@ -20,6 +19,7 @@
   "dependencies": {
     "argparse": "^1.0.10",
     "dotenv": "^6.1.0",
-    "isomorphic-fetch": "^2.2.1"
+    "isomorphic-fetch": "^2.2.1",
+    "serialize-error": "^3.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import serializeError from 'serialize-error'
 import fetchAuthStepDescription from './authorizePocketApp'
 import fetchAccessToken from './fetchAccessToken'
 import fetchList from './fetchList'
@@ -42,10 +43,11 @@ if (process.env.TERMINAL === 'true') {
   }
 }
 
-export default (request, response) => {
+export default (_, response) => {
   const consumerKey = process.env.CONSUMER_KEY
   const accessToken = process.env.ACCESS_TOKEN
   const pocketTag = process.env.POCKET_TAG
+  const screenshotServiceUrl = process.env.SCREENSHOT_SERVICE_URL
 
   fetchList(consumerKey, accessToken, pocketTag)
     .then((pocketResponse) => {
@@ -54,7 +56,7 @@ export default (request, response) => {
     .catch((error) => {
       response.statusCode = 500
       response.json({
-        error: error
+        error: serializeError(error)
       })
     })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4840,6 +4840,11 @@ scoped-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
+serialize-error@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-3.0.0.tgz#80100282b09be33c611536f50033481cb9cc87cf"
+  integrity sha512-+y3nkkG/go1Vdw+2f/+XUXM1DXX1XcxTl99FfiD/OEPUNw4uo0i6FKABfTAN5ZcgGtjTRZcEbxcE/jtXbEY19A==
+
 serialize-javascript@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.5.0.tgz#1aa336162c88a890ddad5384baebc93a655161fe"


### PR DESCRIPTION
Other improvements:
- replace unused "request" variable with "_"
- fix error response by using serialize-error npm package